### PR TITLE
Fix Turing ext usage of array names

### DIFF
--- a/ext/TuringExt/TuringSBCGenerator.jl
+++ b/ext/TuringExt/TuringSBCGenerator.jl
@@ -68,8 +68,8 @@ function SBC.run_comparison(generator::TuringSBCGenerator, n::Int, n_comparisons
         primary = run_primary_generative(generator)
         secondary = run_secondary_generative(generator, primary.primary_sample, n)
         # Collect the rank statistics whilst keeping the variable names
-        pairs_form = primary.primary_target |> pairs |> collect
-        rank_statistic = map(pairs_form) do P
+        full_pairs_form = SBC._full_pairs_form(primary)
+        rank_statistic = map(full_pairs_form) do P
             name = P.first
             target = P.second
             return (name, sum(secondary.samples[name] .< target))

--- a/test/ext/TuringExt/TuringSBCGenerator.jl
+++ b/test/ext/TuringExt/TuringSBCGenerator.jl
@@ -29,7 +29,18 @@ end
 end
 
 # Test the run_comparison function
-@testitem "run_comparison" setup=[TestModel1] begin
+@testitem "run_comparison: scalar dists" setup=[TestModel1] begin
+    turing_generator = sbc_generator(turing_model, condition_names, sampler)
+    n = 10
+    n_comparisons = 10
+    results = run_comparison(turing_generator, n, n_comparisons)
+    rank_length_bools = map(results.rank_statistics) do rank
+        length(rank) == n_comparisons
+    end
+    @test all(rank_length_bools)
+end
+
+@testitem "run_comparison: array dists" setup=[TestModel2] begin
     turing_generator = sbc_generator(turing_model, condition_names, sampler)
     n = 10
     n_comparisons = 10

--- a/test/ext/TuringExt/test_models.jl
+++ b/test/ext/TuringExt/test_models.jl
@@ -1,8 +1,23 @@
+# Model with only scalar distributions
 @testsnippet TestModel1 begin
     using Turing
     @model function test_model()
         mu ~ Normal(0, 1)
         x ~ Normal(mu, 1)
+        return x
+    end
+    sampler = NUTS()
+    condition_names = (:x,)
+    turing_model = test_model()
+end
+
+# Model with array distribution
+@testsnippet TestModel2 begin
+    using Turing
+    nd = 10
+    @model function test_model()
+        mu ~ filldist(Normal(0, 1), nd)
+        x ~ arraydist([Normal(m, 1) for m in mu])
         return x
     end
     sampler = NUTS()

--- a/test/src/utils.jl
+++ b/test/src/utils.jl
@@ -62,3 +62,31 @@ end
     # Check the result
     @test result_nt == expected_nt
 end
+
+@testitem "SBC._full_pairs_form basic functionality" begin
+    # Test case 1: Scalar values
+    primary = (primary_target = (a = 1, b = 2),)
+    result = SBC._full_pairs_form(primary)
+    expected = [Pair(:a, 1), Pair(:b, 2)]
+    @test result == expected
+
+    # Test case 2: Array values
+    primary = (primary_target = (a = [1, 2], b = [3, 4]),)
+    result = SBC._full_pairs_form(primary)
+    expected = [Pair(Symbol("a[1]"), 1), Pair(Symbol("a[2]"), 2),
+        Pair(Symbol("b[1]"), 3), Pair(Symbol("b[2]"), 4)]
+    @test result == expected
+
+    # Test case 3: Mixed scalar and array values
+    primary = (primary_target = (a = 1, b = [2, 3]),)
+    result = SBC._full_pairs_form(primary)
+    expected = [Pair(:a, 1), Pair(Symbol("b[1]"), 2), Pair(Symbol("b[2]"), 3)]
+    @test result == expected
+
+    # Test case 4: Multi-dimensional array values
+    primary = (primary_target = (a = [1 2; 3 4],),)
+    result = SBC._full_pairs_form(primary)
+    expected = [Pair(Symbol("a[1, 1]"), 1), Pair(Symbol("a[1, 2]"), 2),
+        Pair(Symbol("a[2, 1]"), 3), Pair(Symbol("a[2, 2]"), 4)]
+    @test setdiff(result, expected) |> isempty #invariant test to ordering
+end


### PR DESCRIPTION
The current state of SBC on main allows for only scalar distributions in Turing extension. I spotted this, fixed and made additional unit tests.